### PR TITLE
Add better Pedestal TESR

### DIFF
--- a/src/main/java/mcjty/modtut/blocks/itempedestal/PedestalBlock.java
+++ b/src/main/java/mcjty/modtut/blocks/itempedestal/PedestalBlock.java
@@ -4,6 +4,9 @@ import mcjty.modtut.ModTut;
 import net.minecraft.block.Block;
 import net.minecraft.block.ITileEntityProvider;
 import net.minecraft.block.material.Material;
+import net.minecraft.block.properties.IProperty;
+import net.minecraft.block.properties.PropertyBool;
+import net.minecraft.block.state.BlockStateContainer;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.renderer.block.model.ModelResourceLocation;
 import net.minecraft.entity.item.EntityItem;
@@ -22,11 +25,34 @@ import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 
 public class PedestalBlock extends Block implements ITileEntityProvider {
+    // Used for visuals only
+    public static final IProperty<Boolean> IS_HANDLES = PropertyBool.create("is_handles");
 
     public PedestalBlock() {
         super(Material.ROCK);
         setUnlocalizedName(ModTut.MODID + ".pedestalblock");
         setRegistryName("pedestalblock");
+        setDefaultState(blockState.getBaseState().withProperty(IS_HANDLES, false));
+    }
+
+    @Override
+    public IBlockState getActualState(IBlockState state, IBlockAccess worldIn, BlockPos pos) {
+        return state.withProperty(IS_HANDLES, false);
+    }
+
+    @Override
+    protected BlockStateContainer createBlockState() {
+        return new BlockStateContainer(this, IS_HANDLES);
+    }
+
+    @Override
+    public IBlockState getStateFromMeta(int meta) {
+        return getDefaultState();
+    }
+
+    @Override
+    public int getMetaFromState(IBlockState state) {
+        return 0;
     }
 
     @SideOnly(Side.CLIENT)

--- a/src/main/java/mcjty/modtut/blocks/itempedestal/PedestalTESR.java
+++ b/src/main/java/mcjty/modtut/blocks/itempedestal/PedestalTESR.java
@@ -1,47 +1,23 @@
 package mcjty.modtut.blocks.itempedestal;
 
+import mcjty.modtut.ModBlocks;
 import mcjty.modtut.ModTut;
+import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
-import net.minecraft.client.renderer.GlStateManager;
-import net.minecraft.client.renderer.RenderHelper;
-import net.minecraft.client.renderer.Tessellator;
+import net.minecraft.client.renderer.*;
 import net.minecraft.client.renderer.block.model.IBakedModel;
 import net.minecraft.client.renderer.block.model.ItemCameraTransforms;
 import net.minecraft.client.renderer.texture.TextureMap;
 import net.minecraft.client.renderer.tileentity.TileEntitySpecialRenderer;
 import net.minecraft.client.renderer.vertex.DefaultVertexFormats;
 import net.minecraft.item.ItemStack;
-import net.minecraft.util.ResourceLocation;
 import net.minecraft.world.World;
-import net.minecraftforge.client.model.IModel;
-import net.minecraftforge.client.model.ModelLoaderRegistry;
-import net.minecraftforge.common.model.TRSRTransformation;
 import net.minecraftforge.fml.relauncher.Side;
 import net.minecraftforge.fml.relauncher.SideOnly;
 import org.lwjgl.opengl.GL11;
 
 @SideOnly(Side.CLIENT)
 public class PedestalTESR extends TileEntitySpecialRenderer<PedestalTileEntity> {
-
-    private IModel model;
-    private IBakedModel bakedModel;
-
-    private IBakedModel getBakedModel() {
-        // Since we cannot bake in preInit() we do lazy baking of the model as soon as we need it
-        // for rendering
-        if (bakedModel == null) {
-            try {
-                model = ModelLoaderRegistry.getModel(new ResourceLocation(ModTut.MODID, "block/pedestalhandles.obj"));
-            } catch (Exception e) {
-                throw new RuntimeException(e);
-            }
-            bakedModel = model.bake(TRSRTransformation.identity(), DefaultVertexFormats.ITEM,
-                    location -> Minecraft.getMinecraft().getTextureMapBlocks().getAtlasSprite(location.toString()));
-        }
-        return bakedModel;
-    }
-
-
     @Override
     public void render(PedestalTileEntity te, double x, double y, double z, float partialTicks, int destroyStage, float alpha) {
         GlStateManager.pushAttrib();
@@ -82,13 +58,13 @@ public class PedestalTESR extends TileEntitySpecialRenderer<PedestalTileEntity> 
         GlStateManager.translate(-te.getPos().getX(), -te.getPos().getY(), -te.getPos().getZ());
 
         Tessellator tessellator = Tessellator.getInstance();
-        tessellator.getBuffer().begin(GL11.GL_QUADS, DefaultVertexFormats.BLOCK);
-        Minecraft.getMinecraft().getBlockRendererDispatcher().getBlockModelRenderer().renderModel(
-                world,
-                getBakedModel(),
-                world.getBlockState(te.getPos()),
-                te.getPos(),
-                Tessellator.getInstance().getBuffer(), false);
+        BufferBuilder bufferBuilder = tessellator.getBuffer();
+        bufferBuilder.begin(GL11.GL_QUADS, DefaultVertexFormats.BLOCK);
+
+        IBlockState state = ModBlocks.pedestalBlock.getDefaultState().withProperty(PedestalBlock.IS_HANDLES, true);
+        BlockRendererDispatcher dispatcher = Minecraft.getMinecraft().getBlockRendererDispatcher();
+        IBakedModel model = dispatcher.getModelForState(state);
+        dispatcher.getBlockModelRenderer().renderModel(world, model, state, te.getPos(), bufferBuilder, true);
         tessellator.draw();
 
         RenderHelper.enableStandardItemLighting();

--- a/src/main/java/mcjty/modtut/blocks/itempedestal/PedestalTESR.java
+++ b/src/main/java/mcjty/modtut/blocks/itempedestal/PedestalTESR.java
@@ -1,7 +1,6 @@
 package mcjty.modtut.blocks.itempedestal;
 
 import mcjty.modtut.ModBlocks;
-import mcjty.modtut.ModTut;
 import net.minecraft.block.state.IBlockState;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.renderer.*;

--- a/src/main/resources/assets/modtut/blockstates/pedestalblock.json
+++ b/src/main/resources/assets/modtut/blockstates/pedestalblock.json
@@ -1,11 +1,11 @@
 {
   "forge_marker": 1,
   "defaults": {
-    "custom": { "flip-v": true },
-    "model": "modtut:pedestal.obj"
+    "custom": { "flip-v": true }
   },
   "variants": {
-    "normal": [{}],
-    "inventory": [{}]
+    "is_handles=false": { "model": "modtut:pedestal.obj" },
+    "is_handles=true": { "model": "modtut:pedestalhandles.obj" },
+    "inventory": { "model": "modtut:pedestal.obj" }
   }
 }


### PR DESCRIPTION
The current implementation has a few problems:

1) It will not update the model on resource reload and could potentially break when the texture map changes #24.
2) It bakes models outside the built-in model baking pipeline. This makes using textures difficult: They are not loaded automatically. Textures have to be referenced by other models or added to the texture map manually.

This attempts to solve both problems by using the built-in model baking pipeline. It adds the "is_handles" property which is used to distinguish the two models that make up the pedestal. It's a bit of a hack, but it should be generally safer.

If you have any questions about the implementation, don't hesistate to ask.