### PR TITLE
Fix index of player container slots

### DIFF
--- a/src/main/java/mcjty/modtut/blocks/testcontainer/TestContainer.java
+++ b/src/main/java/mcjty/modtut/blocks/testcontainer/TestContainer.java
@@ -31,7 +31,7 @@ public class TestContainer extends Container {
             for (int col = 0; col < 9; ++col) {
                 int x = 10 + col * 18;
                 int y = row * 18 + 70;
-                this.addSlotToContainer(new Slot(playerInventory, col + row * 9 + 10, x, y));
+                this.addSlotToContainer(new Slot(playerInventory, col + row * 9 + 9, x, y));
             }
         }
 


### PR DESCRIPTION
You could access the boots slot form the inventory. The main inventory item slots index should start at 9, not 10. As the hotbar has slots 0-8, slot 9 was getting ignored and the last of them was one of the armor slots.