### PR TITLE
Parent OBJ block to Forge default block transform

### DIFF
--- a/src/main/resources/assets/modtut/blockstates/modelblock.json
+++ b/src/main/resources/assets/modtut/blockstates/modelblock.json
@@ -2,7 +2,8 @@
   "forge_marker": 1,
   "defaults": {
     "custom": { "flip-v": true },
-    "model": "modtut:model.obj"
+    "model": "modtut:model.obj",
+    "transform": "forge:default-block"
   },
   "variants": {
     "normal": [{}],


### PR DESCRIPTION
This fixes incorrect sizing when in hand, inventory, item frames, on ground, etc.